### PR TITLE
[Fix] Fix a bug for ModelSkillConfigurator.

### DIFF
--- a/src/app/models/sceneMain/ModelSkillConfigurator.lua
+++ b/src/app/models/sceneMain/ModelSkillConfigurator.lua
@@ -187,10 +187,12 @@ local function initItemsAllConfigurations(self)
             name     = getConfigurationTitle(i),
             callback = function()
                 setStateOverviewConfiguration(self, i)
-                WebSocketManager.sendAction({
-                    actionName      = "GetSkillConfiguration",
-                    configurationID = i,
-                })
+                if (WebSocketManager.getLoggedInAccountAndPassword()) then
+                    WebSocketManager.sendAction({
+                        actionName      = "GetSkillConfiguration",
+                        configurationID = i,
+                    })
+                end
             end,
         }
     end


### PR DESCRIPTION
The main scene is reloaded if the player try to config skills without logging in.
